### PR TITLE
update: b10c-nix flake input for fork-observer fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760027435,
-        "narHash": "sha256-3jcluIlomUlrQ9T8EwerBjqg28/lK0BAgG+kVKSCjbA=",
+        "lastModified": 1760535305,
+        "narHash": "sha256-aM3jf4NHM4PmngPxguPi+lpC5XwER8MCvD2Hi0MyHX4=",
         "owner": "0xb10c",
         "repo": "nix",
-        "rev": "47f5a02ad242fa682e9fedc99177facaac36623c",
+        "rev": "d11d350a37ce498c7bf0fe487a8d95c177cc8067",
         "type": "github"
       },
       "original": {

--- a/tests/test-infra.nix
+++ b/tests/test-infra.nix
@@ -34,7 +34,10 @@ in
       id = 1;
       setup = false;
       arch = system;
-      description = "This is the test-node1. An unique value to look for in the integration tests is: 0fc83a94-3eee-44c2-87b4-441638dd75ac";
+      description = ''
+        This is the test-node1.
+        An unique value to look for in the integration tests is: 0fc83a94-3eee-44c2-87b4-441638dd75ac";
+      '';
 
       wireguard = {
         ip = "10.0.0.1";

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -64,8 +64,8 @@ pkgs.testers.runNixOSTest {
     command = "curl 127.0.0.1:${toString CONSTANTS.NGINX_INTERNAL_FULL_ACCESS_PORT}"
     output = web1.succeed(command)
     print(f"{command}: {output}")
-    assert_log("${infraConfig.nodes.node1.description}", output)
-    assert_log("${infraConfig.nodes.node2.description}", output)
+    assert_log("""${infraConfig.nodes.node1.description}""", output)
+    assert_log("""${infraConfig.nodes.node2.description}""", output)
 
     # without trailing slash
     command = "curl 127.0.0.1:${toString CONSTANTS.NGINX_INTERNAL_FULL_ACCESS_PORT}/addrman"
@@ -161,12 +161,12 @@ pkgs.testers.runNixOSTest {
     command = "curl 127.0.0.1:${toString CONSTANTS.NGINX_INTERNAL_LIMITED_ACCESS_PORT}/forks/api/networks.json"
     output = web1.succeed(command)
     print(f"{command}: {output}")
-    assert_log('{"networks":[{"id":1,"name":"regtest","description":"fork-observer attached to peer-observer nodes"}]}', output)
+    assert_log('{"networks":[{"id":1,"name":"regtest","description":"  fork-observer attached to peer-observer nodes"}]}', output)
     command = "curl 127.0.0.1:${toString CONSTANTS.NGINX_INTERNAL_LIMITED_ACCESS_PORT}/forks/api/1/data.json"
     output = web1.succeed(command)
     print(f"{command}: {output}")
-    assert_log("${infraConfig.nodes.node1.description}", output)
-    assert_log("${infraConfig.nodes.node2.description}", output)
+    assert_log("0fc83a94-3eee-44c2-87b4-441638dd75ac", output)
+    assert_log("09b318bd-fb84-48b3-9984-5f60ebddf864", output)
     assert_log('"status":"active","height":500', output)
 
     # TODO: test addrLookup


### PR DESCRIPTION
to get https://github.com/0xB10C/nix/pull/220 and use a multi-line description in the test

```
• Updated input 'b10c-nix':
    'github:0xb10c/nix/47f5a02ad242fa682e9fedc99177facaac36623c?narHash=sha256-3jcluIlomUlrQ9T8EwerBjqg28/lK0BAgG%2BkVKSCjbA%3D' (2025-10-09)
  → 'github:0xb10c/nix/d11d350a37ce498c7bf0fe487a8d95c177cc8067?narHash=sha256-aM3jf4NHM4PmngPxguPi%2BlpC5XwER8MCvD2Hi0MyHX4%3D' (2025-10-15)
```

