### PR TITLE
update: b10c-nixpkgs flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761819414,
-        "narHash": "sha256-w4ZLnoUOs57jDDXDpChkGU/G3UNcb8g9oEVcT04lUwE=",
+        "lastModified": 1762702760,
+        "narHash": "sha256-Ucy/hEa9FqwJDS5if95VB14R09uDL6H+OGAi6yksaJg=",
         "owner": "0xb10c",
         "repo": "nix",
-        "rev": "f68cc0038b6f3d9379bcde94496a5401ef1b819c",
+        "rev": "dbc26648298d67582ababa5efa64f1046401b60f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
• Updated input 'b10c-nix':
    'github:0xb10c/nix/f68cc0038b6f3d9379bcde94496a5401ef1b819c?narHash=sha256-w4ZLnoUOs57jDDXDpChkGU/G3UNcb8g9oEVcT04lUwE%3D' (2025-10-30)
  → 'github:0xb10c/nix/dbc26648298d67582ababa5efa64f1046401b60f?narHash=sha256-Ucy/hEa9FqwJDS5if95VB14R09uDL6H%2BOGAi6yksaJg%3D' (2025-11-09)
```