### PR TITLE
add: support custom bitcoind P2P port

### DIFF
--- a/tests/test-infra.nix
+++ b/tests/test-infra.nix
@@ -67,7 +67,7 @@ in
           bitcoin-cli setban 2604:d500:4:1::/64 add 31536000  # LinkingLion
         '';
         extraConfig = ''
-          addnode=node2:18444
+          addnode=node2:12345
         '';
       };
 
@@ -88,6 +88,7 @@ in
       };
       bitcoind = {
         chain = "regtest";
+        customPort = 12345;
         detailedLogging = {
           printToConsole = true; # useful for debugging
         };

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -83,12 +83,10 @@ pkgs.testers.runNixOSTest {
     node2.wait_for_unit("bitcoind-mainnet.service")
 
     print("from node1, check if node2's Bitcoin node port is reachable and vice-versa")
-    node1.wait_for_open_port(${
-      toString CONSTANTS.BITCOIND_P2P_PORT_BY_CHAIN."${infraConfig.nodes.node2.bitcoind.chain}"
-    }, addr="node2");
+    node1.wait_for_open_port(${toString infraConfig.nodes.node2.bitcoind.customPort}, addr="node2", timeout=60);
     node2.wait_for_open_port(${
       toString CONSTANTS.BITCOIND_P2P_PORT_BY_CHAIN."${infraConfig.nodes.node1.bitcoind.chain}"
-    }, addr="node1");
+    }, addr="node1", timeout=60);
 
     node1.wait_for_unit("nats.service")
     node1.wait_for_open_port(4222)


### PR DESCRIPTION
Previously, the firewall was only opened for the default port and not custom ports.