### PR TITLE
update: flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1754433428,
-        "narHash": "sha256-NA/FT2hVhKDftbHSwVnoRTFhes62+7dxZbxj5Gxvghs=",
+        "lastModified": 1762618334,
+        "narHash": "sha256-wyT7Pl6tMFbFrs8Lk/TlEs81N6L+VSybPfiIgzU8lbQ=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "9edb1787864c4f59ae5074ad498b6272b3ec308d",
+        "rev": "fcdea223397448d35d9b31f798479227e80183f6",
         "type": "github"
       },
       "original": {
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766477091,
-        "narHash": "sha256-/eZXI1z2Jm9+Rt82vPSChko0emBPqvDtzmxbPtTzW+E=",
+        "lastModified": 1767114706,
+        "narHash": "sha256-P/EEMZtnfYDYNkNjgP7z7gWUzrSE1uKPMIbduc5ASy8=",
         "owner": "0xb10c",
         "repo": "nix",
-        "rev": "936ec890f57e703f2aa5cd0bad254e73a663637c",
+        "rev": "cd537f4f3d6776bc9a1b7138beec6f1a9529c696",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764522689,
-        "narHash": "sha256-SqUuBFjhl/kpDiVaKLQBoD8TLD+/cTUzzgVFoaHrkqY=",
+        "lastModified": 1766885793,
+        "narHash": "sha256-P6RVkrM9JLCW6xBjSwHfgTOQ1JwBUma5xe5LI8xAPC0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8bb5646e0bed5dbd3ab08c7a7cc15b75ab4e1d0f",
+        "rev": "9ef261221d1e72399f2036786498d78c38185c46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
• Updated input 'agenix':
    'github:ryantm/agenix/9edb1787864c4f59ae5074ad498b6272b3ec308d?narHash=sha256-NA/FT2hVhKDftbHSwVnoRTFhes62%2B7dxZbxj5Gxvghs%3D' (2025-08-05)
  → 'github:ryantm/agenix/fcdea223397448d35d9b31f798479227e80183f6?narHash=sha256-wyT7Pl6tMFbFrs8Lk/TlEs81N6L%2BVSybPfiIgzU8lbQ%3D' (2025-11-08)
• Updated input 'b10c-nix':
    'github:0xb10c/nix/936ec890f57e703f2aa5cd0bad254e73a663637c?narHash=sha256-/eZXI1z2Jm9%2BRt82vPSChko0emBPqvDtzmxbPtTzW%2BE%3D' (2025-12-23)
  → 'github:0xb10c/nix/cd537f4f3d6776bc9a1b7138beec6f1a9529c696?narHash=sha256-P/EEMZtnfYDYNkNjgP7z7gWUzrSE1uKPMIbduc5ASy8%3D' (2025-12-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/8bb5646e0bed5dbd3ab08c7a7cc15b75ab4e1d0f?narHash=sha256-SqUuBFjhl/kpDiVaKLQBoD8TLD%2B/cTUzzgVFoaHrkqY%3D' (2025-11-30)
  → 'github:nixos/nixpkgs/9ef261221d1e72399f2036786498d78c38185c46?narHash=sha256-P6RVkrM9JLCW6xBjSwHfgTOQ1JwBUma5xe5LI8xAPC0%3D' (2025-12-28)
```