### PR TITLE
add: new RPCs to rpc-extractor whitelist

### DIFF
--- a/modules/node/node.nix
+++ b/modules/node/node.nix
@@ -188,7 +188,7 @@ in
           server=1
 
           # rpc-extractor (peer-observer) user
-          rpcwhitelist=rpc-extractor:getpeerinfo,getmempoolinfo,uptime,getnettotals,getaddrmaninfo,getmemoryinfo
+          rpcwhitelist=rpc-extractor:getpeerinfo,getmempoolinfo,uptime,getnettotals,getaddrmaninfo,getmemoryinfo,getchaintxstats,getnetworkinfo,getblockchaininfo
           rpcauth=rpc-extractor:${CONSTANTS.RPC_EXTRACTOR_RPC_AUTH}
         ''}
         ${optionalString (config.peer-observer.node.bitcoind.banlistScript != null) ''


### PR DESCRIPTION
These were recently added to peer-observer rpc-extractor, but aren't yet supported here.

- getchaintxstats
- getnetworkinfo
- getblockchaininfo