### PR TITLE
add: concurrency group for ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, assigned, unassigned]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   nix-fmt:
     name: nix fmt


### PR DESCRIPTION
Follows up on https://github.com/peer-observer/infra-library/pull/89/changes/8880c76a1fd0262fee4956ca70ddc515e1a1c0e3 adding a conncurrency group for the other workflow. 

This was proposed by @deadmanoz in https://github.com/peer-observer/infra-library/pull/88#discussion_r2785769266