### PR TITLE
add: badge for continues profiling on nodes

### DIFF
--- a/modules/web/index.html.nix
+++ b/modules/web/index.html.nix
@@ -126,6 +126,9 @@ let
               ${lib.optionalString host.peer-observer.addrLookup ''
                 <span class="badge text-bg-success">addr connectivity check</span>
               ''}
+              ${lib.optionalString (host.parca) ''
+                <span class="badge text-bg-success">continues profiling</span>
+              ''}
             </p>
     ''
     + (


### PR DESCRIPTION
followup to https://github.com/peer-observer/infra-library/pull/93

Shows a badge with "continues profiling" on the nodes where it's enabled on the index start page.