### PR TITLE
add: option to enable log-extractor

### DIFF
--- a/modules/node/node.nix
+++ b/modules/node/node.nix
@@ -117,7 +117,14 @@ in
     };
 
     peer-observer = {
+      extractors = {
+        logs = {
+          enable = lib.mkEnableOption "the peer-observer log-extractor";
+        };
+      };
+
       addrLookup = lib.mkEnableOption "the peer-observer address-connectivity lookup tool. This reaches out to nodes on the network and might leak IP addresses.";
+
     };
 
     parca = lib.mkEnableOption "parca.dev continues profiling on the node. This runs the parca-agent and the parca-server. The agent runs as root, so think about what that means for the host before you enable it.";

--- a/tests/test-infra.nix
+++ b/tests/test-infra.nix
@@ -70,7 +70,11 @@ in
           addnode=node2:12345
         '';
       };
-      peer-observer.addrLookup = true;
+
+      peer-observer = {
+        extractors.logs.enable = true;
+        addrLookup = true;
+      };
 
       parca = true;
 


### PR DESCRIPTION
While we don't have https://github.com/peer-observer/peer-observer/issues/276 yet, it makes sense to be able to enable the log-extractor selectivly. 