### PR TITLE
fix(web): add nginx user to acme group for HTTP-01 challenge serving

### DIFF
--- a/modules/web/web.nix
+++ b/modules/web/web.nix
@@ -194,6 +194,13 @@ in
       }
     ];
 
+    # Allow nginx to read ACME challenge files for HTTP-01 validation.
+    # Without this, /var/lib/acme/acme-challenge (owned acme:acme, mode 750)
+    # is unreadable by the nginx worker, causing 403 on renewal attempts.
+    # See: https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/security/acme/default.md
+    users.groups.acme = { };
+    users.users.${config.services.nginx.user}.extraGroups = [ "acme" ];
+
     services.nginx = {
       enable = true;
 

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -103,6 +103,16 @@ pkgs.testers.runNixOSTest {
       web1.wait_for_unit("wireguard-${CONSTANTS.WIREGUARD_INTERFACE_NAME}.service")
       # web2 doesn't have a wireguard interface as it's "setup = true;"
 
+    def check_nginx_in_acme_group():
+      """Verify the nginx user is in the acme group so it can serve ACME
+      HTTP-01 challenge files from /var/lib/acme/acme-challenge."""
+      web1.wait_for_unit("nginx.service")
+      print("check that the nginx worker user is in the acme group on web1")
+      nginx_user = web1.succeed("ps -o user= -C nginx | grep -v root | head -1").strip()
+      print(f"nginx worker runs as: {nginx_user}")
+      output = web1.succeed(f"groups {nginx_user}")
+      assert_log("acme", output)
+
     def check_for_index_on_webserver():
       print("check for index.html.nix on web1")
       web1.wait_for_unit("nginx.service")
@@ -237,6 +247,8 @@ pkgs.testers.runNixOSTest {
 
     web1.wait_for_unit("grafana.service")
     web1.wait_for_unit("prometheus.service")
+
+    check_nginx_in_acme_group()
 
     check_for_index_on_webserver()
 


### PR DESCRIPTION
The ACME challenge dir (`/var/lib/acme/acme-challenge`) is created by NixOS with ownership `acme:acme` and mode `750`. The nginx worker can't read it, so Let's Encrypt gets a 403 on the HTTP-01 challenge path and certificate renewal fails. The nginx config already has `auth_request off` on that location, the problem is purely filesystem permissions.

This adds `users.users.${config.services.nginx.user}.extraGroups = [ "acme" ];` so nginx can traverse the challenge dir. Uses `config.services.nginx.user` rather than hardcoding `"nginx"` so it works for consumers that override the nginx user. Includes a regression test that discovers the nginx worker user at runtime and verifies it's in the `acme` group.

## Context

Noticed this on production where the `acme-order-renew-<hostname>.service` had been stuck in `failed` for a few days. The logs showed a 403 from Let's Encrypt on the HTTP-01 challenge. The challenge dir showed `acme:acme` ownership while the cert output dir already had `acme:nginx`, so only the challenge dir was missing the correct group.

## Testing

- Manually verified on my production system: after adding nginx to the acme group, the challenge path became readable (was returning 403) and `systemctl start acme-order-renew-...` succeeded