### PR TITLE
remove: nats-top due to broken tests

### DIFF
--- a/modules/node/node.nix
+++ b/modules/node/node.nix
@@ -555,8 +555,6 @@ in
       # the peer-observer tools and extractors as packages
       # e.g. `$ logger`
       config.peer-observer.base.b10c-pkgs.peer-observer
-      # useful to see NATS server load
-      pkgs.nats-top
     ];
 
   };


### PR DESCRIPTION
We don't really need nats-top (and always get it in PATH with a nix-shell), and it's broken at the moment:

```
--- FAIL: TestMonitoringTLSConnectionUsingRootCA (0.03s)
    toputils_test.go:373: Could not monitor number of cores. got: 0
--- FAIL: TestMonitoringTLSConnectionUsingRootCAWithCerts (0.03s)
    toputils_test.go:406: Could not monitor number of cores. got: 0
FAIL
FAIL    github.com/nats-io/nats-top/util        0.160s
FAIL
error: Cannot build '/nix/store/54anagykykv9q9prz58v24cxnk6s77q4-nats-top-0.6.3.drv'.
```