### PR TITLE
Support for alerts and archiver tool

### DIFF
--- a/modules/node/node.nix
+++ b/modules/node/node.nix
@@ -124,6 +124,26 @@ in
           };
         };
       };
+      tools = {
+        archiver = {
+          enable = lib.mkEnableOption "the peer-observer archiver";
+
+          baseName = mkOption {
+            type = types.str;
+            default = null;
+            example = "demo-peer-observer";
+            description = "Base name for archive files (e.g., 'mainnet' -> '[node-name]-mainnet.<timestamp>.bin.zst')";
+          };
+
+          compressionLevel = mkOption {
+            type = types.ints.between 0 22;
+            default = 9;
+            example = 3;
+            description = "Zstd compression level (0 = no compression, 1-22)";
+          };
+
+        };
+      };
 
       addrLookup = lib.mkEnableOption "the peer-observer address-connectivity lookup tool. This reaches out to nodes on the network and might leak IP addresses.";
 
@@ -362,6 +382,13 @@ in
 
         alerts = {
           enable = true;
+        };
+
+        archiver = {
+          enable = config.peer-observer.node.peer-observer.tools.archiver.enable;
+          outputDir = "/data/peer-observer-archives/";
+          baseName = "${config.peer-observer.node.peer-observer.tools.archiver.baseName}-${config.peer-observer.base.name}";
+          compressionLevel = config.peer-observer.node.peer-observer.tools.archiver.compressionLevel;
         };
       };
     };

--- a/modules/node/node.nix
+++ b/modules/node/node.nix
@@ -359,6 +359,10 @@ in
           enable = true;
           websocketAddress = "127.0.0.1:${toString CONSTANTS.PEER_OBSERVER_TOOL_WEBSOCKET_PORT}";
         };
+
+        alerts = {
+          enable = true;
+        };
       };
     };
 

--- a/tests/test-infra.nix
+++ b/tests/test-infra.nix
@@ -73,6 +73,11 @@ in
 
       peer-observer = {
         extractors.logs.enable = true;
+        tools.archiver = {
+          enable = true;
+          baseName = "infra-test";
+          compressionLevel = 1;
+        };
         addrLookup = true;
       };
 

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -269,6 +269,11 @@ pkgs.testers.runNixOSTest {
     node1.wait_for_unit("peer-observer-tool-websocket.service")
     node2.wait_for_unit("peer-observer-tool-websocket.service")
 
+    node1.wait_for_unit("peer-observer-tool-alerts.service")
+    node2.wait_for_unit("peer-observer-tool-alerts.service")
+
+    node1.wait_for_unit("peer-observer-tool-archiver.service")
+
     wait_until_nodes_connected()
 
     check_bitcoind_rpc_connectivity()


### PR DESCRIPTION
The alerts tool is turned on by default and the archiver tool is off by default, as it will write large files to disk.