### PR TITLE
add: enable ipc-extractor by default

### DIFF
--- a/modules/node/node.nix
+++ b/modules/node/node.nix
@@ -123,6 +123,11 @@ in
             default = true;
           };
         };
+        ipc = {
+          enable = lib.mkEnableOption "the peer-observer ipc-extractor" // {
+            default = true;
+          };
+        };
       };
       tools = {
         archiver = {
@@ -215,6 +220,9 @@ in
 
         ${optionalString (config.services.peer-observer.extractors.p2p.enable) ''
           addnode=${config.services.peer-observer.extractors.p2p.p2pAddress}
+        ''}
+        ${optionalString (config.services.peer-observer.extractors.ipc.enable) ''
+          ipcbind=unix:/run/bitcoind-mainnet/node.sock
         ''}
         ${optionalString (config.services.peer-observer.extractors.rpc.enable) ''
           server=1
@@ -336,6 +344,15 @@ in
       };
     };
 
+    assertions = [
+      {
+        assertion =
+          config.peer-observer.node.peer-observer.extractors.ipc.enable
+          == config.peer-observer.node.bitcoind.package.symlinkBitcoinNode;
+        message = "ipc-extractor enabled, but bitcoin-node not symlinked on ${config.peer-observer.base.name}";
+      }
+    ];
+
     services.peer-observer = {
       extractors = {
         dependOn = "bitcoind-mainnet";
@@ -361,6 +378,10 @@ in
         log = {
           enable = config.peer-observer.node.peer-observer.extractors.logs.enable;
           debugLog = "/var/lib/bitcoind-mainnet/debug.log";
+        };
+        ipc = {
+          enable = config.peer-observer.node.peer-observer.extractors.ipc.enable;
+          ipcSocket = "/run/bitcoind-mainnet/node.sock";
         };
       };
 

--- a/pkgs/bitcoind/default.nix
+++ b/pkgs/bitcoind/default.nix
@@ -25,6 +25,9 @@
   gitCommit ? "6574cb40869b96b9ffc79c19dc8f4e467d60f321", # v31.0
   sanitizersAddressUndefined ? false,
   sanitizersThread ? false,
+  # by default, symlink the bitcoin-node binary into the location of
+  # bitcoind. The original bitcoind binary is renamed to bitcoind_.
+  symlinkBitcoinNode ? true,
 }:
 
 # ensure either thread or address+undefined sanitizers are enabled
@@ -50,6 +53,7 @@ stdenv.mkDerivation rec {
       gitURL
       sanitizersAddressUndefined
       sanitizersThread
+      symlinkBitcoinNode
       ;
   };
 
@@ -116,6 +120,13 @@ stdenv.mkDerivation rec {
   # -fno-optimize-sibling-calls: Avoid tail-call elimination
   preConfigure = ''
     export CXXFLAGS="$CXXFLAGS -ggdb3 -fno-omit-frame-pointer -fno-inline -fno-optimize-sibling-calls"
+  '';
+
+  # This is required as the NixOS bitcoind service only supports running
+  # /bin/bitcoind and we can't choose to run /libexec/bitcoin-node.
+  postInstall = lib.optional symlinkBitcoinNode ''
+    mv $out/bin/bitcoind $out/bin/bitcoind_
+    ln -s $out/libexec/bitcoin-node $out/bin/bitcoind
   '';
 
   doCheck = false;

--- a/tests/test-infra.nix
+++ b/tests/test-infra.nix
@@ -47,7 +47,10 @@ in
       bitcoind = {
         chain = "regtest";
         # for good measure, use a custom bitcoind binary here.
-        package = peer-observer-infra-library.mkCustomBitcoind { sanitizersAddressUndefined = true; };
+        package = peer-observer-infra-library.mkCustomBitcoind {
+          sanitizersAddressUndefined = true;
+          symlinkBitcoinNode = true;
+        };
         net = {
           useTor = true;
           useI2P = true;

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -78,6 +78,9 @@ pkgs.testers.runNixOSTest {
       assert_log("peerobserver_rpc_mempoolinfo_memory_max 300000000", output)
       assert_log("peerobserver_rpc_peer_info_num_peers 1", output)
 
+      print("check that the ipc-extractor works..")
+      assert_log("peerobserver_ipc_block_tip_height 20", output)
+
     def check_fork_observer():
       web1.wait_for_unit("fork-observer.service")
       print("wait for fork-observer to do its first getchaintips query..")
@@ -138,7 +141,7 @@ pkgs.testers.runNixOSTest {
       print("mine a few blocks on node2")
       command = bitcoin_cli + " generatetoaddress 20 bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw"
       node2.succeed(command)
-      
+
       # give nodes a bit of time to sync
       time.sleep(4)
 
@@ -173,7 +176,7 @@ pkgs.testers.runNixOSTest {
               assert_log("HTTP/1.1 101 Switching Protocols", output)
             case "${CONSTANTS.NODE_TO_WEBSERVER_PATH_BITCOIND_RPC}":
               # Bitcoin Core RPC doesn't like HEAD requests, but that's fine as it means: Bitcoin Core is reachable
-              assert_log("HTTP/1.1 405 Method Not Allowed", output)  
+              assert_log("HTTP/1.1 405 Method Not Allowed", output)
             case _:
               assert_log("HTTP/1.1 200 OK", output)
 
@@ -262,6 +265,9 @@ pkgs.testers.runNixOSTest {
     node1.wait_for_open_port(${toString CONSTANTS.PEER_OBSERVER_EXTRACTOR_P2P_PORT})
     node2.wait_for_unit("peer-observer-p2p-extractor.service")
     node2.wait_for_open_port(${toString CONSTANTS.PEER_OBSERVER_EXTRACTOR_P2P_PORT})
+
+    node1.wait_for_unit("peer-observer-ipc-extractor.service")
+    node2.wait_for_unit("peer-observer-ipc-extractor.service")
 
     node1.wait_for_unit("peer-observer-tool-metrics.service")
     node2.wait_for_unit("peer-observer-tool-metrics.service")


### PR DESCRIPTION
We also run `bitcoin-node` instead of `bitcoind` now.