### PR TITLE
add: run bitcoind with sanitizer suppressions

### DIFF
--- a/modules/node/node.nix
+++ b/modules/node/node.nix
@@ -185,6 +185,35 @@ in
     # or restarting the whole host). Calling the "stop" RPC also causes the node to be NOT restarted.
     # See https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Restart=
     systemd.services.bitcoind-mainnet.serviceConfig.Restart = lib.mkForce "no";
+    systemd.services.bitcoind-mainnet.serviceConfig.LimitCORE = mkIf (
+      config.peer-observer.node.bitcoind.package.sanitizersAddressUndefined
+      || config.peer-observer.node.bitcoind.package.sanitizersThread
+    ) "infinity";
+
+    # Raise systemd-coredump limits for sanitizer builds so dumps aren't
+    # silently truncated. Core dumps land in /var/lib/systemd/coredump/ and
+    # are accessible via `coredumpctl list / coredumpctl dump`.
+    systemd.coredump.extraConfig =
+      mkIf
+        (
+          config.peer-observer.node.bitcoind.package.sanitizersAddressUndefined
+          || config.peer-observer.node.bitcoind.package.sanitizersThread
+        )
+        ''
+          ExternalSizeMax=infinity
+          ProcessSizeMax=infinity
+        '';
+
+    systemd.services.bitcoind-mainnet.environment = mkMerge [
+      (mkIf config.peer-observer.node.bitcoind.package.sanitizersAddressUndefined {
+        ASAN_OPTIONS = "detect_leaks=1:abort_on_error=1:halt_on_error=1";
+        LSAN_OPTIONS = "suppressions=${config.peer-observer.node.bitcoind.package.sanitizerSuppressionsDir}/lsan:print_stacktrace=1:halt_on_error=1";
+        UBSAN_OPTIONS = "suppressions=${config.peer-observer.node.bitcoind.package.sanitizerSuppressionsDir}/ubsan:print_stacktrace=1:halt_on_error=1";
+      })
+      (mkIf config.peer-observer.node.bitcoind.package.sanitizersThread {
+        TSAN_OPTIONS = "suppressions=${config.peer-observer.node.bitcoind.package.sanitizerSuppressionsDir}/tsan:print_stacktrace=1:halt_on_error=1:second_deadlock_stack=1:verbosity=1";
+      })
+    ];
 
     # for backwards compatability reasons, this is called "mainnet" and has to stay this way for now.
     # Even if we run a signet/testnet/regtest node..

--- a/pkgs/bitcoind/default.nix
+++ b/pkgs/bitcoind/default.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
       sanitizersAddressUndefined
       sanitizersThread
       ;
+    sanitizerSuppressionsDir = "${src}/test/sanitizer_suppressions";
   };
 
   src = builtins.fetchGit {

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -138,7 +138,7 @@ pkgs.testers.runNixOSTest {
       print("mine a few blocks on node2")
       command = bitcoin_cli + " generatetoaddress 20 bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw"
       node2.succeed(command)
-      
+
       # give nodes a bit of time to sync
       time.sleep(4)
 
@@ -173,7 +173,7 @@ pkgs.testers.runNixOSTest {
               assert_log("HTTP/1.1 101 Switching Protocols", output)
             case "${CONSTANTS.NODE_TO_WEBSERVER_PATH_BITCOIND_RPC}":
               # Bitcoin Core RPC doesn't like HEAD requests, but that's fine as it means: Bitcoin Core is reachable
-              assert_log("HTTP/1.1 405 Method Not Allowed", output)  
+              assert_log("HTTP/1.1 405 Method Not Allowed", output)
             case _:
               assert_log("HTTP/1.1 200 OK", output)
 
@@ -246,6 +246,28 @@ pkgs.testers.runNixOSTest {
       print(f"{command}: {output}")
       assert_log("HTTP/1.1 200 OK", output)
 
+    def check_sanitizer_suppressions():
+      print("checking sanitizer env vars are set on node1 bitcoind (sanitizersAddressUndefined=true)")
+      output = node1.succeed("systemctl show bitcoind-mainnet.service --property=Environment")
+      assert_log("ASAN_OPTIONS=", output)
+      assert_log("LSAN_OPTIONS=", output)
+      assert_log("UBSAN_OPTIONS=", output)
+      assert_log("halt_on_error=1", output)
+      assert_log("print_stacktrace=1", output)
+      assert_log("abort_on_error=1", output)
+      assert_log("TSAN_OPTIONS=", output, negated=True)
+
+      print("checking LimitCORE=infinity is set on node1 bitcoind (sanitizersAddressUndefined=true)")
+      output = node1.succeed("systemctl show bitcoind-mainnet.service --property=LimitCORE")
+      assert_log("LimitCORE=infinity", output)
+
+      print("checking no sanitizer env vars are set on node2 bitcoind (no sanitizers)")
+      output = node2.succeed("systemctl show bitcoind-mainnet.service --property=Environment")
+      assert_log("ASAN_OPTIONS=", output, negated=True)
+      assert_log("LSAN_OPTIONS=", output, negated=True)
+      assert_log("UBSAN_OPTIONS=", output, negated=True)
+      assert_log("TSAN_OPTIONS=", output, negated=True)
+
     start_all()
 
     check_for_wireguard()
@@ -256,6 +278,8 @@ pkgs.testers.runNixOSTest {
     web2.wait_for_unit("multi-user.target")
 
     check_parca()
+
+    check_sanitizer_suppressions()
 
     check_node_webserver_interface()
 
@@ -268,6 +292,13 @@ pkgs.testers.runNixOSTest {
 
     node1.wait_for_unit("bitcoind-mainnet.service")
     node2.wait_for_unit("bitcoind-mainnet.service")
+
+    print("verifying sanitizer env vars are present in the running bitcoind process on node1")
+    pid = node1.succeed("systemctl show bitcoind-mainnet.service --property=MainPID --value").strip()
+    environ = node1.succeed(f"cat /proc/{pid}/environ | tr '\\0' '\\n'")
+    assert_log("ASAN_OPTIONS=", environ)
+    assert_log("LSAN_OPTIONS=", environ)
+    assert_log("UBSAN_OPTIONS=", environ)
 
     check_bitcoind_p2p_port_reachable()
 


### PR DESCRIPTION
and actually make sure it crashes when triggering, and that we have logs for it

closes: https://github.com/peer-observer/infra-library/issues/20