### PR TITLE
update: NixOS 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,16 +88,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A NixOS flake providing library functionality for running peer-observer instances.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-26.05";
     b10c-nix = {
       url = "github:0xb10c/nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/node/node.nix
+++ b/modules/node/node.nix
@@ -198,16 +198,16 @@ in
     # Raise systemd-coredump limits for sanitizer builds so dumps aren't
     # silently truncated. Core dumps land in /var/lib/systemd/coredump/ and
     # are accessible via `coredumpctl list / coredumpctl dump`.
-    systemd.coredump.extraConfig =
+    systemd.coredump.settings.Coredump =
       mkIf
         (
           config.peer-observer.node.bitcoind.package.sanitizersAddressUndefined
           || config.peer-observer.node.bitcoind.package.sanitizersThread
         )
-        ''
-          ExternalSizeMax=infinity
-          ProcessSizeMax=infinity
-        '';
+        {
+          ExternalSizeMax = "infinity";
+          ProcessSizeMax = "infinity";
+        };
 
     systemd.services.bitcoind-mainnet.environment = mkMerge [
       (mkIf config.peer-observer.node.bitcoind.package.sanitizersAddressUndefined {

--- a/modules/web/web.nix
+++ b/modules/web/web.nix
@@ -439,6 +439,9 @@ in
           admin_password = "$__file{${config.age.secrets.grafana-admin-password.path}}";
           admin_user = config.peer-observer.web.grafana.admin_user;
           cookie_secure = true;
+          # This hardcodes the old NixOS Grafana secret key, as we don't really have anything sentitive
+          # in our database by default. YMMV.
+          secret_key = "SW2YcwTIb9zpOOhoPsMm";
         };
         # https://github.com/grafana/grafana/issues/54974#issuecomment-1787591644
         rbac = {

--- a/modules/web/web.nix
+++ b/modules/web/web.nix
@@ -420,6 +420,7 @@ in
       # We manually provision the grafana side.
       # (see "rendering" below)
       provisionGrafana = false;
+      settings.security.authToken = "library-peer-observer-renderer";
     };
 
     services.grafana = {
@@ -459,6 +460,7 @@ in
           # callback_url needs the "/monitoring" subpath!
           callback_url = "http://127.0.0.1:${toString CONSTANTS.GRAFANA_PORT}/monitoring";
           server_url = "http://127.0.0.1:${toString config.services.grafana-image-renderer.settings.service.port}/render";
+          renderer_token = "library-peer-observer-renderer";
         };
       };
       provision =


### PR DESCRIPTION

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/25f538306313eae3927264466c70d7001dcea1df?narHash=sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY%3D' (2026-05-26)
  → 'github:nixos/nixpkgs/b51242d7d43689db2f3be91bd05d5b24fbb469c4?narHash=sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1%2BN6cArVE%3D' (2026-05-31)
``