### PR TITLE
change: test CJDNS again

### DIFF
--- a/tests/test-infra.nix
+++ b/tests/test-infra.nix
@@ -55,8 +55,7 @@ in
           useTor = true;
           useI2P = true;
           useASMap = true;
-          # CJDNS package is broken?
-          useCJDNS = false;
+          useCJDNS = true;
         };
         detailedLogging = {
           enable = true;


### PR DESCRIPTION
The package was broken, but seems to be fixed now. Enable this in the test again to notice when it breaks again.