### PR TITLE
add: enable leveldb debug logs

### DIFF
--- a/modules/constants.nix
+++ b/modules/constants.nix
@@ -77,6 +77,7 @@ rec {
     "bench"
     "txpackages"
     "mempool" # since 2024-05-04
+    "leveldb" # since 2026-06-04
   ];
 
   FORK_OBSERVER_PORT = 2839;


### PR DESCRIPTION
We've recently seen problems with leveldb compactions here and there, so it makes sense to have this going forward. Apparently, it's not too spammy.