### PR TITLE
add: expose addrman snapshots via web servers

### DIFF
--- a/modules/web/addrman-snapshots.html.nix
+++ b/modules/web/addrman-snapshots.html.nix
@@ -1,0 +1,69 @@
+{
+  config,
+  stdenv,
+  lib,
+  ...
+}:
+
+let
+  mkHTMLPage = title: body: ''
+      <!doctype html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>${title}</title>
+        </head>
+        <body>
+          <div class="container">
+            ${body}
+          </div>
+        </body>
+    </html>
+  '';
+
+  # only nodes that have addrman snapshots enabled are listed.
+  snapshotNodes = lib.filterAttrs (
+    name: host: host.bitcoind.addrmanSnapshots.enable
+  ) config.infra.nodes;
+
+  mkOverviewNodeEntry = name: host: ''
+    <li>
+      node <a href="/addrman-snapshots/${name}/">${name}</a>
+      (last ${toString host.bitcoind.addrmanSnapshots.snapshotsToKeep} days${lib.optionalString host.bitcoind.net.useTor "; tor enabled"}${lib.optionalString host.bitcoind.net.useI2P "; i2p enabled"}${lib.optionalString host.bitcoind.net.useCJDNS "; cjdns enabled"})
+    </li>
+  '';
+
+  mkOverviewNodeList = hosts: ''
+    <div class="row">
+      ${builtins.concatStringsSep "  " (lib.mapAttrsToList mkOverviewNodeEntry hosts)}
+    </div>
+  '';
+
+in
+stdenv.mkDerivation {
+  name = "addrman-snapshots-page";
+
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+        mkdir -p $out
+        cat > $out/index.html << EOF
+        ${
+          (mkHTMLPage "peer-observer addrman snapshots" (''
+            <h1>peer-observer addrman snapshots</h1>
+            <span>
+              Daily <code>getrawaddrman</code> snapshots of the node's address manager are kept.
+              They are compressed with zstd (<code>.json.zst</code>) and provided as is.
+              <br>
+              Feel free to use the snapshots but please make sure to not leak the node IP addresses to the public.
+            </span>
+            <h2>snapshots</h2>
+            <ul>
+              ${(mkOverviewNodeList snapshotNodes)}
+            </ul>
+          ''))
+        }
+    EOF
+  '';
+}

--- a/modules/web/index.html.nix
+++ b/modules/web/index.html.nix
@@ -37,6 +37,7 @@ let
                         <a class="nav-link" href="/monitoring/d/home/home">monitoring</a>
                         <a class="nav-link" href="/monitoring/playlists">playlist</a>
                         <a class="nav-link" href="/debug-logs/">debug logs</a>
+                        <a class="nav-link" href="/addrman-snapshots/">addrman snapshots</a>
                         <a class="nav-link" href="/websocket/">websocket</a>
                       ''
                     else
@@ -166,6 +167,11 @@ let
               <a href="${
                 if limited then "nice try" else "/debug-logs/${name}/"
               }" class="btn btn-outline-secondary ${lib.optionalString limited "disabled"}">debug.log</a>
+              ${lib.optionalString host.bitcoind.addrmanSnapshots.enable ''
+                <a href="${
+                  if limited then "nice try" else "/addrman-snapshots/${name}/"
+                }" class="btn btn-outline-secondary ${lib.optionalString limited "disabled"}">addrman snapshots</a>
+              ''}
             </div>
           </div>
         </div>

--- a/modules/web/web.nix
+++ b/modules/web/web.nix
@@ -23,6 +23,8 @@ let
 
   debugLogPage = (pkgs.callPackage ./debug-logs.html.nix) { inherit config; };
 
+  addrmanSnapshotsPage = (pkgs.callPackage ./addrman-snapshots.html.nix) { inherit config; };
+
   mkForkObserverNode = name: host: {
     inherit (host) id description;
     inherit name;
@@ -56,6 +58,16 @@ let
     name: host:
     (lib.nameValuePair ("/debug-logs/${name}/") ({
       proxyPass = "http://${host.wireguard.ip}:${toString CONSTANTS.NODE_TO_WEBSERVER_PORT}${CONSTANTS.NODE_TO_WEBSERVER_PATH_DEBUG_LOGS}";
+      extraConfig = ''
+        limit_rate 500k; # kB/s
+      '';
+    }));
+
+  # Only nodes with addrman snapshots enabled expose the snapshots endpoint.
+  mkAddrmanSnapshotsLocation =
+    name: host:
+    (lib.nameValuePair ("/addrman-snapshots/${name}/") ({
+      proxyPass = "http://${host.wireguard.ip}:${toString CONSTANTS.NODE_TO_WEBSERVER_PORT}${CONSTANTS.NODE_TO_WEBSERVER_PATH_ADDRMAN_SNAPSHOTS}";
       extraConfig = ''
         limit_rate 500k; # kB/s
       '';
@@ -303,6 +315,19 @@ in
               '';
             };
 
+            "/addrman-snapshots" = {
+              extraConfig = "rewrite /addrman-snapshots /addrman-snapshots/ redirect;";
+            };
+            "/addrman-snapshots/" = {
+              root = "${addrmanSnapshotsPage}";
+              index = "index.html";
+              tryFiles = "$uri $uri/index.html $uri/ =404";
+              extraConfig = ''
+                default_type text/html;
+                rewrite /addrman-snapshots/(.*) /$1  break;
+              '';
+            };
+
             "/websocket" = {
               extraConfig = "rewrite /websocket /websocket/ redirect;";
             };
@@ -323,7 +348,10 @@ in
             '';
           }
           // (lib.mapAttrs' mkWebsocketLocation (config.infra.nodes))
-          // (lib.mapAttrs' mkDebugLogLocation (config.infra.nodes));
+          // (lib.mapAttrs' mkDebugLogLocation (config.infra.nodes))
+          // (lib.mapAttrs' mkAddrmanSnapshotsLocation (
+            lib.filterAttrs (name: host: host.bitcoind.addrmanSnapshots.enable) config.infra.nodes
+          ));
         };
 
         # Users can and should overwrite this, if they want to e.g. put FULL_ACCESS

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -288,6 +288,26 @@ pkgs.testers.runNixOSTest {
       print(f"{command}: {output}")
       assert_log("HTTP/1.1 200 OK", output)
 
+      print("checking the FULL_ACCESS frontend serves the addrman-snapshots index page")
+      # without trailing slash
+      command = "curl 127.0.0.1:${toString CONSTANTS.NGINX_INTERNAL_FULL_ACCESS_PORT}/addrman-snapshots"
+      output = web1.succeed(command)
+      print(f"{command}: {output}")
+      assert_log("302 Found", output)
+
+      # with trailing slash, the index page lists the nodes
+      command = "curl 127.0.0.1:${toString CONSTANTS.NGINX_INTERNAL_FULL_ACCESS_PORT}/addrman-snapshots/"
+      output = web1.succeed(command)
+      print(f"{command}: {output}")
+      assert_log("peer-observer addrman snapshots", output)
+      assert_log("/addrman-snapshots/node1/", output)
+
+      print("checking the FULL_ACCESS frontend proxies a snapshot from node1")
+      command = f"curl -s -I 127.0.0.1:${toString CONSTANTS.NGINX_INTERNAL_FULL_ACCESS_PORT}/addrman-snapshots/node1/{snapshot_name}"
+      output = web1.succeed(command)
+      print(f"{command}: {output}")
+      assert_log("HTTP/1.1 200 OK", output)
+
     def check_sanitizer_suppressions():
       print("checking sanitizer env vars are set on node1 bitcoind (sanitizersAddressUndefined=true)")
       output = node1.succeed("systemctl show bitcoind-mainnet.service --property=Environment")


### PR DESCRIPTION
#160 added capturing daily addrman snapshots. We expose them from the nodes via the webserver(s) here. This allows to download them.