### PR TITLE
fix: don't let samply profiling resurrect a crashed bitcoind

### DIFF
--- a/modules/node/profiling.nix
+++ b/modules/node/profiling.nix
@@ -70,7 +70,16 @@ in
       description = "samply CPU profiling of bitcoind (${toString cfg.duration}s captures at ${toString cfg.rate}Hz)";
       wantedBy = [ "multi-user.target" ];
       after = [ cfg.bitcoindService ];
-      bindsTo = [ cfg.bitcoindService ];
+      # Track bitcoind downward only: stop/restart *with* bitcoind, but never
+      # start it. Using bindsTo here (or requires) would give this unit
+      # Requires-style activation semantics, so its own Restart=always cycle
+      # would pull a stopped bitcoind back up after a crash/OOM-kill and defeat
+      # the `Restart = "no"` on bitcoind-mainnet (see infra-library issue #190).
+      # partOf propagates bitcoind's stop/restart down to us without pulling it
+      # up; requisite makes our (re)start fail fast unless bitcoind is already
+      # running, instead of samply looping on a missing PID file.
+      partOf = [ cfg.bitcoindService ];
+      requisite = [ cfg.bitcoindService ];
 
       serviceConfig = {
         Type = "simple";

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -225,6 +225,51 @@ pkgs.testers.runNixOSTest {
       print("triggering bitcoind-profiling-cleanup.service on node1")
       node1.succeed("systemctl start bitcoind-profiling-cleanup.service")
 
+    def check_bitcoind_no_restart_on_crash():
+      """Regression test for infra-library issue #190: after a crash/OOM-kill
+      bitcoind must NOT be automatically restarted, and the samply
+      bitcoind-profiling unit must not resurrect it via a requirement
+      dependency. node1 has samply-continuous-profiling enabled (the case that
+      regressed); node2 does not. This is destructive to bitcoind on node1, so
+      it runs last."""
+      import time
+
+      print("verifying bitcoind-mainnet has Restart=no on node1 and node2")
+      for node in [node1, node2]:
+        restart = node.succeed(
+          "systemctl show bitcoind-mainnet.service --property=Restart --value"
+        ).strip()
+        assert restart == "no", f"expected bitcoind-mainnet Restart=no, got {restart!r}"
+
+      print("verifying bitcoind-profiling has no upward (pull-up) dependency on bitcoind on node1")
+      # After/PartOf/Requisite are fine (no upward activation). Requires/BindsTo/
+      # Wants would let the profiler's Restart=always cycle start a stopped
+      # bitcoind back up and defeat Restart=no.
+      for prop in ["Requires", "BindsTo", "Wants"]:
+        deps = node1.succeed(
+          f"systemctl show bitcoind-profiling.service --property={prop} --value"
+        ).strip()
+        assert "bitcoind-mainnet.service" not in deps, \
+          f"bitcoind-profiling {prop} must not contain bitcoind-mainnet.service, got: {deps!r}"
+
+      node1.wait_for_unit("bitcoind-profiling.service")
+
+      print("simulating an OOM-kill of bitcoind on node1 (SIGKILL of the whole unit)")
+      node1.succeed("systemctl kill --signal=SIGKILL bitcoind-mainnet.service")
+
+      print("waiting for bitcoind-mainnet to leave the active state on node1")
+      node1.wait_until_fails("systemctl is-active bitcoind-mainnet.service")
+
+      print("giving bitcoind-profiling's Restart=always (RestartSec=10s) a chance to resurrect it")
+      time.sleep(30)
+
+      print("verifying bitcoind-mainnet stayed down (was NOT auto-restarted)")
+      node1.fail("systemctl is-active bitcoind-mainnet.service")
+
+      print("verifying bitcoind can still be started manually again on node1")
+      node1.succeed("systemctl start bitcoind-mainnet.service")
+      node1.wait_for_unit("bitcoind-mainnet.service")
+
     def check_prometheus_scrape_config():
       """Verify each remote-node Prometheus scrape job uses the correct URL path
       from CONSTANTS. Catches bugs where the wrong metrics_path or port
@@ -410,6 +455,9 @@ pkgs.testers.runNixOSTest {
     check_fork_observer()
 
     check_prometheus_scrape_config()
+
+    # Runs last: it kills bitcoind on node1 to assert it is not auto-restarted.
+    check_bitcoind_no_restart_on_crash()
 
     # TODO: test addrLookup
     # TODO: test logrotate (logrotate currently might only work on mainnet..)


### PR DESCRIPTION
The bitcoind-profiling unit used bindsTo + Restart=always. bindsTo has Requires-style activation semantics, so when bitcoind was OOM-killed (Restart=no, meant to stay down so the crash is noticed), samply exited and the profiler's restart cycle pulled bitcoind back up, defeating Restart=no.

Use partOf instead (propagates bitcoind's stop/restart downward without starting it) plus requisite (the profiler's own (re)start fails fast if bitcoind isn't already running). Add a regression test that SIGKILLs bitcoind on the samply-enabled node and asserts it is not auto-restarted.

Closes https://github.com/peer-observer/infra-library/issues/190