### PR TITLE
add: weekly peers.dat snapshots

### DIFF
--- a/modules/constants.nix
+++ b/modules/constants.nix
@@ -7,6 +7,7 @@ rec {
   NODE_TO_WEBSERVER_PATH_BITCOIND_RPC = "/"; # RPC needs to be / ...
   NODE_TO_WEBSERVER_PATH_DEBUG_LOGS = "/debug-logs/";
   NODE_TO_WEBSERVER_PATH_ADDRMAN_SNAPSHOTS = "/addrman-snapshots/";
+  NODE_TO_WEBSERVER_PATH_PEERS_DAT_SNAPSHOTS = "/peers-dat-snapshots/";
   NODE_TO_WEBSERVER_PATH_PROFILING = "/samply-profiling/";
   NODE_TO_WEBSERVER_PATH_PEER_OBSERVER_RPC_EXTRACTOR_METRICS = "/peer-observer-rpc-extractor-metrics/";
   NODE_TO_WEBSERVER_PATH_PEER_OBSERVER_IPC_EXTRACTOR_METRICS = "/peer-observer-ipc-extractor-metrics/";
@@ -22,6 +23,7 @@ rec {
     NODE_TO_WEBSERVER_PATH_BITCOIND_RPC
     NODE_TO_WEBSERVER_PATH_DEBUG_LOGS
     NODE_TO_WEBSERVER_PATH_ADDRMAN_SNAPSHOTS
+    NODE_TO_WEBSERVER_PATH_PEERS_DAT_SNAPSHOTS
     NODE_TO_WEBSERVER_PATH_PEER_OBSERVER_RPC_EXTRACTOR_METRICS
     NODE_TO_WEBSERVER_PATH_PEER_OBSERVER_IPC_EXTRACTOR_METRICS
     NODE_TO_WEBSERVER_PATH_PEER_OBSERVER_METRICS_TOOL
@@ -49,6 +51,16 @@ rec {
     "regtest" = 18444;
   };
 
+  # Subdirectory of the bitcoind datadir where chain-specific files
+  # like peers.dat are stored.
+  BITCOIND_DATADIR_SUBDIR_BY_CHAIN = {
+    "main" = "";
+    "test" = "testnet3/";
+    "testnet4" = "testnet4/";
+    "signet" = "signet/";
+    "regtest" = "regtest/";
+  };
+
   PEER_OBSERVER_EXTRACTOR_P2P_NETWORK_NAME_MAP = {
     "main" = "mainnet";
     "test" = "testnet3";
@@ -62,6 +74,9 @@ rec {
 
   # Place where addrman snapshots are stored
   ADDRMAN_SNAPSHOTS_DIR = "/data/addrman-snapshots";
+
+  # Place where peers.dat snapshots are stored
+  PEERS_DAT_SNAPSHOTS_DIR = "/data/peers-dat-snapshots";
 
   # A UDP port exposed by the web hosts for nodes to connect to them.
   WIREGUARD_INTERFACE_PORT = 51820;

--- a/modules/node/node.nix
+++ b/modules/node/node.nix
@@ -116,6 +116,20 @@ in
           example = 7;
         };
       };
+
+      peersDatSnapshots = {
+        enable =
+          lib.mkEnableOption "periodic snapshots of the node's peers.dat file. Snapshots are compressed with zstd and stored weekly."
+          // {
+            default = true;
+          };
+        snapshotsToKeep = lib.mkOption {
+          type = lib.types.ints.u16;
+          description = "Number of weekly snapshots to keep on the server before deleting them.";
+          default = 26;
+          example = 4;
+        };
+      };
     };
 
     fork-observer = {
@@ -520,9 +534,13 @@ in
       serviceConfig.Type = "oneshot";
     };
 
-    systemd.tmpfiles.rules = mkIf config.peer-observer.node.bitcoind.addrmanSnapshots.enable [
-      "d ${CONSTANTS.ADDRMAN_SNAPSHOTS_DIR} 775 ${config.services.bitcoind.mainnet.user} ${config.services.bitcoind.mainnet.group} -"
-    ];
+    systemd.tmpfiles.rules =
+      optionals config.peer-observer.node.bitcoind.addrmanSnapshots.enable [
+        "d ${CONSTANTS.ADDRMAN_SNAPSHOTS_DIR} 775 ${config.services.bitcoind.mainnet.user} ${config.services.bitcoind.mainnet.group} -"
+      ]
+      ++ optionals config.peer-observer.node.bitcoind.peersDatSnapshots.enable [
+        "d ${CONSTANTS.PEERS_DAT_SNAPSHOTS_DIR} 775 ${config.services.bitcoind.mainnet.user} ${config.services.bitcoind.mainnet.group} -"
+      ];
 
     systemd.services."addrman-snapshot" =
       mkIf config.peer-observer.node.bitcoind.addrmanSnapshots.enable
@@ -550,6 +568,45 @@ in
           wantedBy = [ "timers.target" ];
           timerConfig = {
             OnCalendar = "daily";
+            Persistent = true;
+          };
+        };
+
+    systemd.services."peers-dat-snapshot" =
+      mkIf config.peer-observer.node.bitcoind.peersDatSnapshots.enable
+        {
+          after = [ "bitcoind-mainnet.service" ];
+          script = ''
+            set -e
+            # Bitcoin Core writes peers.dat atomically (write to peers.dat.new,
+            # then rename) every 15 minutes, so copying it here is safe. The
+            # snapshot is at most 15 minutes stale.
+            DATE=$(date +%Y%m%d)
+            PEERS_DAT="${config.services.bitcoind.mainnet.dataDir}/${
+              CONSTANTS.BITCOIND_DATADIR_SUBDIR_BY_CHAIN."${config.peer-observer.node.bitcoind.chain}"
+            }peers.dat"
+            SNAPSHOT="${CONSTANTS.PEERS_DAT_SNAPSHOTS_DIR}/peers-$DATE-${config.peer-observer.base.name}.dat.zst"
+            # Read peers.dat via stdin (rather than passing it as a file
+            # argument) so the compressed output gets default permissions
+            # instead of inheriting peers.dat's restrictive 0600 mode, which
+            # would stop nginx from serving it. The open fd also gives us a
+            # consistent point-in-time read even if bitcoind rewrites the file.
+            ${pkgs.zstd}/bin/zstd -19 -o "$SNAPSHOT" < "$PEERS_DAT"
+            find ${CONSTANTS.PEERS_DAT_SNAPSHOTS_DIR} -name "peers-*.dat.zst" \
+              -mtime +${toString (config.peer-observer.node.bitcoind.peersDatSnapshots.snapshotsToKeep * 7)} \
+              -delete
+          '';
+          serviceConfig = {
+            Type = "oneshot";
+          };
+        };
+
+    systemd.timers."peers-dat-snapshot" =
+      mkIf config.peer-observer.node.bitcoind.peersDatSnapshots.enable
+        {
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnCalendar = "weekly";
             Persistent = true;
           };
         };
@@ -622,6 +679,18 @@ in
             mkIf config.peer-observer.node.bitcoind.addrmanSnapshots.enable
               {
                 alias = "${CONSTANTS.ADDRMAN_SNAPSHOTS_DIR}/";
+                extraConfig = ''
+                  autoindex on;
+                  autoindex_exact_size off;
+                  limit_rate 500k; # kB/s
+                '';
+              };
+
+          # access to peers.dat snapshots the node hasn't deleted yet.
+          "${CONSTANTS.NODE_TO_WEBSERVER_PATH_PEERS_DAT_SNAPSHOTS}" =
+            mkIf config.peer-observer.node.bitcoind.peersDatSnapshots.enable
+              {
+                alias = "${CONSTANTS.PEERS_DAT_SNAPSHOTS_DIR}/";
                 extraConfig = ''
                   autoindex on;
                   autoindex_exact_size off;

--- a/modules/web/addrman-snapshots.html.nix
+++ b/modules/web/addrman-snapshots.html.nix
@@ -22,22 +22,49 @@ let
     </html>
   '';
 
-  # only nodes that have addrman snapshots enabled are listed.
+  # only nodes that have at least one kind of addrman snapshot enabled are listed.
   snapshotNodes = lib.filterAttrs (
-    name: host: host.bitcoind.addrmanSnapshots.enable
+    name: host: host.bitcoind.addrmanSnapshots.enable || host.bitcoind.peersDatSnapshots.enable
   ) config.infra.nodes;
 
-  mkOverviewNodeEntry = name: host: ''
-    <li>
-      node <a href="/addrman-snapshots/${name}/">${name}</a>
-      (last ${toString host.bitcoind.addrmanSnapshots.snapshotsToKeep} days${lib.optionalString host.bitcoind.net.useTor "; tor enabled"}${lib.optionalString host.bitcoind.net.useI2P "; i2p enabled"}${lib.optionalString host.bitcoind.net.useCJDNS "; cjdns enabled"})
-    </li>
-  '';
+  # a comma separated list of the node's enabled privacy networks, e.g. "tor, i2p".
+  mkNetFlags =
+    host:
+    lib.concatStringsSep ", " (
+      lib.optional host.bitcoind.net.useTor "tor"
+      ++ lib.optional host.bitcoind.net.useI2P "i2p"
+      ++ lib.optional host.bitcoind.net.useCJDNS "cjdns"
+    );
+
+  mkOverviewNodeEntry =
+    name: host:
+    let
+      flags = mkNetFlags host;
+    in
+    ''
+      <li>
+        node ${name}${lib.optionalString (flags != "") " (${flags})"}
+        <ul>
+          ${lib.optionalString host.bitcoind.addrmanSnapshots.enable ''
+            <li>
+              <a href="/addrman-snapshots/${name}/"><code>getrawaddrman</code> snapshots</a>
+              (last ${toString host.bitcoind.addrmanSnapshots.snapshotsToKeep} days)
+            </li>
+          ''}
+          ${lib.optionalString host.bitcoind.peersDatSnapshots.enable ''
+            <li>
+              <a href="/peers-dat-snapshots/${name}/"><code>peers.dat</code> snapshots</a>
+              (last ${toString host.bitcoind.peersDatSnapshots.snapshotsToKeep} weeks)
+            </li>
+          ''}
+        </ul>
+      </li>
+    '';
 
   mkOverviewNodeList = hosts: ''
-    <div class="row">
+    <ul>
       ${builtins.concatStringsSep "  " (lib.mapAttrsToList mkOverviewNodeEntry hosts)}
-    </div>
+    </ul>
   '';
 
 in
@@ -53,15 +80,16 @@ stdenv.mkDerivation {
           (mkHTMLPage "peer-observer addrman snapshots" (''
             <h1>peer-observer addrman snapshots</h1>
             <span>
-              Daily <code>getrawaddrman</code> snapshots of the node's address manager are kept.
-              They are compressed with zstd (<code>.json.zst</code>) and provided as is.
+              Snapshots of each node's address manager are kept: daily
+              <code>getrawaddrman</code> JSON snapshots and weekly raw
+              <code>peers.dat</code> files. The <code>peers.dat</code> files are
+              easier to work with inside Bitcoin Core for e.g. simulations.
+              Both are compressed with zstd and provided as is.
               <br>
               Feel free to use the snapshots but please make sure to not leak the node IP addresses to the public.
             </span>
             <h2>snapshots</h2>
-            <ul>
-              ${(mkOverviewNodeList snapshotNodes)}
-            </ul>
+            ${(mkOverviewNodeList snapshotNodes)}
           ''))
         }
     EOF

--- a/modules/web/index.html.nix
+++ b/modules/web/index.html.nix
@@ -172,6 +172,11 @@ let
                   if limited then "nice try" else "/addrman-snapshots/${name}/"
                 }" class="btn btn-outline-secondary ${lib.optionalString limited "disabled"}">addrman snapshots</a>
               ''}
+              ${lib.optionalString host.bitcoind.peersDatSnapshots.enable ''
+                <a href="${
+                  if limited then "nice try" else "/peers-dat-snapshots/${name}/"
+                }" class="btn btn-outline-secondary ${lib.optionalString limited "disabled"}">peers.dat snapshots</a>
+              ''}
             </div>
           </div>
         </div>

--- a/modules/web/web.nix
+++ b/modules/web/web.nix
@@ -23,6 +23,7 @@ let
 
   debugLogPage = (pkgs.callPackage ./debug-logs.html.nix) { inherit config; };
 
+  # Combined overview page for both getrawaddrman and peers.dat snapshots.
   addrmanSnapshotsPage = (pkgs.callPackage ./addrman-snapshots.html.nix) { inherit config; };
 
   mkForkObserverNode = name: host: {
@@ -68,6 +69,16 @@ let
     name: host:
     (lib.nameValuePair ("/addrman-snapshots/${name}/") ({
       proxyPass = "http://${host.wireguard.ip}:${toString CONSTANTS.NODE_TO_WEBSERVER_PORT}${CONSTANTS.NODE_TO_WEBSERVER_PATH_ADDRMAN_SNAPSHOTS}";
+      extraConfig = ''
+        limit_rate 500k; # kB/s
+      '';
+    }));
+
+  # Only nodes with peers.dat snapshots enabled expose the snapshots endpoint.
+  mkPeersDatSnapshotsLocation =
+    name: host:
+    (lib.nameValuePair ("/peers-dat-snapshots/${name}/") ({
+      proxyPass = "http://${host.wireguard.ip}:${toString CONSTANTS.NODE_TO_WEBSERVER_PORT}${CONSTANTS.NODE_TO_WEBSERVER_PATH_PEERS_DAT_SNAPSHOTS}";
       extraConfig = ''
         limit_rate 500k; # kB/s
       '';
@@ -351,6 +362,9 @@ in
           // (lib.mapAttrs' mkDebugLogLocation (config.infra.nodes))
           // (lib.mapAttrs' mkAddrmanSnapshotsLocation (
             lib.filterAttrs (name: host: host.bitcoind.addrmanSnapshots.enable) config.infra.nodes
+          ))
+          // (lib.mapAttrs' mkPeersDatSnapshotsLocation (
+            lib.filterAttrs (name: host: host.bitcoind.peersDatSnapshots.enable) config.infra.nodes
           ));
         };
 

--- a/tests/test-infra.nix
+++ b/tests/test-infra.nix
@@ -66,6 +66,10 @@ in
           enable = true;
           snapshotsToKeep = 7;
         };
+        peersDatSnapshots = {
+          enable = true;
+          snapshotsToKeep = 4;
+        };
         banlistScript = ''
           bitcoin-cli setban 162.218.65.0/24    add 31536000  # LinkingLion
           bitcoin-cli setban 209.222.252.0/24   add 31536000  # LinkingLion
@@ -116,6 +120,10 @@ in
         addrmanSnapshots = {
           enable = true;
           snapshotsToKeep = 7;
+        };
+        peersDatSnapshots = {
+          enable = true;
+          snapshotsToKeep = 4;
         };
         extraConfig = ''
           addnode=node1:18444

--- a/tests/test.nix
+++ b/tests/test.nix
@@ -295,15 +295,50 @@ pkgs.testers.runNixOSTest {
       print(f"{command}: {output}")
       assert_log("302 Found", output)
 
-      # with trailing slash, the index page lists the nodes
+      # with trailing slash, the combined index page lists the nodes and
+      # links to both the getrawaddrman and peers.dat snapshots per node.
       command = "curl 127.0.0.1:${toString CONSTANTS.NGINX_INTERNAL_FULL_ACCESS_PORT}/addrman-snapshots/"
       output = web1.succeed(command)
       print(f"{command}: {output}")
       assert_log("peer-observer addrman snapshots", output)
       assert_log("/addrman-snapshots/node1/", output)
+      assert_log("/peers-dat-snapshots/node1/", output)
 
       print("checking the FULL_ACCESS frontend proxies a snapshot from node1")
       command = f"curl -s -I 127.0.0.1:${toString CONSTANTS.NGINX_INTERNAL_FULL_ACCESS_PORT}/addrman-snapshots/node1/{snapshot_name}"
+      output = web1.succeed(command)
+      print(f"{command}: {output}")
+      assert_log("HTTP/1.1 200 OK", output)
+
+    def check_peers_dat_snapshots():
+      print("triggering peers-dat-snapshot.service on node1")
+      node1.succeed("systemctl start peers-dat-snapshot.service")
+
+      print("checking that a snapshot file was created in ${CONSTANTS.PEERS_DAT_SNAPSHOTS_DIR}")
+      output = node1.succeed("ls ${CONSTANTS.PEERS_DAT_SNAPSHOTS_DIR}/peers-*.dat.zst")
+      print(f"snapshot files: {output}")
+
+      print("checking snapshot decompresses to a peers.dat with the regtest network magic")
+      node1.succeed(
+        "${pkgs.zstd}/bin/zstd -d -c $(ls ${CONSTANTS.PEERS_DAT_SNAPSHOTS_DIR}/peers-*.dat.zst | head -1) > /tmp/peers-snapshot.dat"
+      )
+      output = node1.succeed("od -An -tx1 -N4 /tmp/peers-snapshot.dat | tr -d ' '")
+      assert_log("fabfb5da", output)
+
+      print("checking webserver can fetch a peers.dat snapshot from node1 via wireguard")
+      snapshot_name = node1.succeed(
+        "ls ${CONSTANTS.PEERS_DAT_SNAPSHOTS_DIR}/peers-*.dat.zst | head -1 | xargs basename"
+      ).strip()
+      command = f"curl -s -I ${infraConfig.nodes.node1.wireguard.ip}:${toString CONSTANTS.NODE_TO_WEBSERVER_PORT}${CONSTANTS.NODE_TO_WEBSERVER_PATH_PEERS_DAT_SNAPSHOTS}{snapshot_name}"
+      output = web1.succeed(command)
+      print(f"{command}: {output}")
+      assert_log("HTTP/1.1 200 OK", output)
+
+      # peers.dat snapshots are listed on the combined addrman-snapshots index
+      # page (see check_addrman_snapshots); here we only check that the
+      # FULL_ACCESS frontend proxies an actual peers.dat snapshot from node1.
+      print("checking the FULL_ACCESS frontend proxies a peers.dat snapshot from node1")
+      command = f"curl -s -I 127.0.0.1:${toString CONSTANTS.NGINX_INTERNAL_FULL_ACCESS_PORT}/peers-dat-snapshots/node1/{snapshot_name}"
       output = web1.succeed(command)
       print(f"{command}: {output}")
       assert_log("HTTP/1.1 200 OK", output)
@@ -402,6 +437,8 @@ pkgs.testers.runNixOSTest {
     wait_until_nodes_connected()
 
     check_addrman_snapshots()
+
+    check_peers_dat_snapshots()
 
     check_bitcoind_rpc_connectivity()
 


### PR DESCRIPTION
Keep weekly zstd-compressed snapshots of each node's peers.dat file and expose them via the webservers, mirroring the daily getrawaddrman snapshots. peers.dat is easier to work with inside Bitcoin Core for e.g. simulations. Old snapshots are pruned after snapshotsToKeep weeks (default 26).

peers.dat is read via stdin so the compressed output gets default permissions instead of inheriting peers.dat's restrictive 0600 mode, which would stop nginx from serving it.

closes: https://github.com/peer-observer/infra-library/issues/173